### PR TITLE
Remove GitLab CI local testing from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,6 @@ node_modules/
 # Auto-generated version files
 esp32/src/version.h
 
-# Local CI testing
-.gitlab-ci-local/
-
 # CMake build directories
 tools/led-sim/build/
 


### PR DESCRIPTION
## Summary
- Removes `.gitlab-ci-local/` entry from `.gitignore` — no longer needed after migrating from GitLab Pages to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)