### PR TITLE
Use PAT in release workflow to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Validate version
         id: tag


### PR DESCRIPTION
## Summary
- Adds `token: ${{ secrets.RELEASE_TOKEN }}` to the prepare job's checkout step
- The PAT bypasses repository ruleset protections, allowing the workflow to push the version-bump commit and tag directly to `main`

## Test plan
- [ ] Merge this PR
- [ ] Run Actions → Release → Run workflow with a test version (e.g., v0.7.0)
- [ ] Verify the prepare job successfully pushes to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)