### PR TITLE
Fix Windows build: use npm ci in CI workflows

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -27,7 +27,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: .
 
       - run: npm run typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run quality checks
         working-directory: rgfx-hub
@@ -150,7 +150,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Download firmware assets
         uses: actions/download-artifact@v4
@@ -199,7 +199,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Download firmware assets
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Replace `npm install` with `npm ci` in all CI workflow steps (release + PR validation)
- Fixes Windows build failure where `@rollup/rollup-win32-x64-msvc` wasn't installed due to [npm optional dependency bug](https://github.com/npm/cli/issues/4828)

## Test plan
- [ ] Merge and re-run release workflow for v1.0.2
- [ ] Verify Windows build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)