### PR TITLE
Fix Windows release build: install rollup Windows binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Windows rollup binary
+        run: npm install @rollup/rollup-win32-x64-msvc
+
       - name: Download firmware assets
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- The lockfile was regenerated on macOS (in PR #22), which stripped resolved entries for non-macOS platform-specific optional deps
- `npm ci` on Windows can't resolve `@rollup/rollup-win32-x64-msvc` without the lockfile entry
- Add an explicit `npm install @rollup/rollup-win32-x64-msvc` step in the Windows release build job

## Test plan
- [ ] Merge and re-run release workflow
- [ ] Verify Windows build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)