### PR TITLE
Remove bundled docs from app package

### DIFF
--- a/rgfx-hub/assets/CLAUDE.md
+++ b/rgfx-hub/assets/CLAUDE.md
@@ -81,4 +81,4 @@ LED hardware definition files (JSON):
 
 ### Build Packaging
 
-Assets are bundled by `forge.config.js` via `extraResource`. The `generateAssets` hook skips the docs build on Windows and in CI environments. The macOS build is unsigned (no Apple Developer certificate) — `entitlements.mac.plist` exists at the hub root for future use if signing is added.
+Assets are bundled by `forge.config.js` via `extraResource`. Documentation is no longer bundled — it is hosted online at rgfx.io/docs. The macOS build is unsigned (no Apple Developer certificate) — `entitlements.mac.plist` exists at the hub root for future use if signing is added.

--- a/rgfx-hub/forge.config.js
+++ b/rgfx-hub/forge.config.js
@@ -5,24 +5,9 @@ const { VitePlugin } = require("@electron-forge/plugin-vite");
 const { FuseV1Options, flipFuses, FuseVersion } = require("@electron/fuses");
 const path = require("path");
 const fs = require("fs");
-const { execSync } = require("child_process");
 
 /** @type {import("@electron-forge/shared-types").ForgeConfig} */
 const config = {
-  hooks: {
-    generateAssets: async () => {
-      // Skip docs build on Windows (requires bash/mkdocs) and in CI (docs are pre-built)
-      if (process.platform === "win32" || process.env.CI) {
-        console.log("Skipping docs build (CI or Windows)");
-        return;
-      }
-      console.log("Building documentation...");
-      execSync("npm run docs:build", {
-        cwd: path.join(__dirname, ".."),
-        stdio: "inherit",
-      });
-    },
-  },
   packagerConfig: {
     appBundleId: "com.rgfx.hub",
     asar: true,
@@ -40,7 +25,6 @@ const config = {
       "./assets/mame",
       "./assets/led-hardware",
       "../LICENSE",
-      "../public-docs/site",
     ],
     // Apply fuses after packaging instead of using the FusesPlugin directly
     afterCopy: [

--- a/rgfx-hub/src/CLAUDE.md
+++ b/rgfx-hub/src/CLAUDE.md
@@ -68,7 +68,7 @@ Key test helpers:
 - `types/` — Shared types split into focused modules:
   - `types/driver.ts` — Driver, telemetry, and LED config types (LEDChipset supports WS2812B/WS2811/SK6812/WS2814, DriverTelemetry includes `ledHealthy?: boolean`)
   - `types/system.ts` — System status and monitoring types
-  - `types/app.ts` — AppInfo and application-level types
+  - `types/app.ts` — AppInfo (version, licensePath, defaultRgfxConfigDir, defaultMameRomsDir) and application-level types
   - `types/global.d.ts` — Global type declarations
   - `types/index.ts` — Barrel re-export for backward-compatible imports via `@/types`
 - `css-modules.d.ts` — CSS module import declarations

--- a/rgfx-hub/src/ipc/CLAUDE.md
+++ b/rgfx-hub/src/ipc/CLAUDE.md
@@ -295,7 +295,6 @@ Uses `getFirmwareDir`/`getFirmwareFilePath` from `utils/firmware-paths` for path
 **Returns:** `AppInfo` object containing:
 - `version` - App version from package.json
 - `licensePath` - Path to LICENSE file
-- `docsPath` - Path to documentation
 - `defaultRgfxConfigDir` - Default `~/.rgfx` config directory
 - `defaultMameRomsDir` - Default `~/mame-roms` directory
 

--- a/rgfx-hub/src/ipc/__tests__/get-app-info-handler.test.ts
+++ b/rgfx-hub/src/ipc/__tests__/get-app-info-handler.test.ts
@@ -114,6 +114,7 @@ describe('registerGetAppInfoHandler', () => {
       expect(result).toHaveProperty('licensePath');
       expect(result).toHaveProperty('defaultRgfxConfigDir');
       expect(result).toHaveProperty('defaultMameRomsDir');
+      expect(result).not.toHaveProperty('docsPath');
     });
   });
 });

--- a/rgfx-hub/src/ipc/get-app-info-handler.ts
+++ b/rgfx-hub/src/ipc/get-app-info-handler.ts
@@ -13,9 +13,6 @@ export function registerGetAppInfoHandler(): void {
       licensePath: app.isPackaged
         ? join(process.resourcesPath, 'LICENSE')
         : join(app.getAppPath(), '..', 'LICENSE'),
-      docsPath: app.isPackaged
-        ? join(process.resourcesPath, 'docs', 'index.html')
-        : join(app.getAppPath(), '..', 'public-docs', 'site', 'index.html'),
       defaultRgfxConfigDir: `${home}/.rgfx`,
       defaultMameRomsDir: `${home}/mame-roms`,
     };

--- a/rgfx-hub/src/renderer/pages/CLAUDE.md
+++ b/rgfx-hub/src/renderer/pages/CLAUDE.md
@@ -223,17 +223,17 @@ Refactored components and utilities extracted from the main page:
 
 ---
 
-### Support Page
+### Help Page
 
-**File:** [support-page.tsx](support-page.tsx)
+**File:** [help-page.tsx](help-page.tsx)
 
-**Route:** `/support`
+**Route:** `/help`
 
 **Purpose:** Documentation and help resources.
 
 **Features:**
-- Button to open bundled documentation in default browser
-- Uses `AppInfoStore` to get documentation path
+- Button to open online documentation (rgfx.io/docs) in default browser via `openExternal`
+- No dependency on `AppInfoStore` — docs URL is a constant
 
 ---
 

--- a/rgfx-hub/src/renderer/pages/help-page.tsx
+++ b/rgfx-hub/src/renderer/pages/help-page.tsx
@@ -5,15 +5,12 @@ import {
   MenuBook as DocsIcon,
 } from '@mui/icons-material';
 import { PageTitle } from '../components/layout/page-title';
-import { useAppInfoStore } from '../store/app-info-store';
+
+const DOCS_URL = 'https://rgfx.io/docs';
 
 const HelpPage: React.FC = () => {
-  const appInfo = useAppInfoStore((state) => state.appInfo);
-
   const handleOpenDocs = () => {
-    if (appInfo?.docsPath) {
-      void window.rgfx.openFile(appInfo.docsPath);
-    }
+    void window.rgfx.openExternal(DOCS_URL);
   };
 
   return (
@@ -31,7 +28,6 @@ const HelpPage: React.FC = () => {
           variant="contained"
           startIcon={<DocsIcon />}
           onClick={handleOpenDocs}
-          disabled={!appInfo?.docsPath}
         >
           Open Documentation
         </Button>

--- a/rgfx-hub/src/types/app.ts
+++ b/rgfx-hub/src/types/app.ts
@@ -4,7 +4,6 @@
 export interface AppInfo {
   version: string;
   licensePath: string;
-  docsPath: string;
   defaultRgfxConfigDir: string;
   defaultMameRomsDir: string;
 }


### PR DESCRIPTION
## Summary
- Remove 46 MB of bundled documentation from the app package — docs are now hosted at rgfx.io/docs
- Help page opens online docs via `shell.openExternal` instead of a local file
- Remove `generateAssets` hook (docs build step) and `docsPath` from `AppInfo`

## Test plan
- [ ] Verify Help page button opens https://rgfx.io/docs in default browser
- [ ] Verify app package no longer contains `public-docs/site`
- [ ] All existing tests pass (2906 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)