### PR TITLE
Fix Windows compatibility for check-code.sh and native ESP32 tests

### DIFF
--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -121,10 +121,13 @@ build_src_filter = +<../tools/i2c_scanner.cpp>
 ; Runs tests on the host machine for fast iteration
 [env:native]
 platform = native
+extra_scripts =
+    pre:scripts/native_platform_flags.py
 build_flags =
     -std=c++17          ; Modern C++ standard (was c++11)
     -DUNIT_TEST         ; Define for conditional compilation (enables mocks)
     -DUNITY_INCLUDE_DOUBLE  ; Enable double precision assertions in Unity
+    -D_USE_MATH_DEFINES ; Required for M_PI/M_PI_2 on MinGW/Windows
     -I src              ; Add src/ to include path for clean includes
     -I src/graphics     ; Graphics module (canvas, coordinate_transforms, etc.)
     -I src/effects      ; Effects module (pulse, wipe, etc.)

--- a/esp32/scripts/native_platform_flags.py
+++ b/esp32/scripts/native_platform_flags.py
@@ -1,0 +1,17 @@
+# native_platform_flags.py - Platform-specific build flag adjustments for native tests
+# Disables AddressSanitizer on Windows (MinGW doesn't ship libasan)
+import platform
+
+Import("env")
+
+if platform.system() == "Windows":
+    # Remove ASan flags that MinGW doesn't support
+    flags_to_remove = ["-fsanitize=address", "-fno-omit-frame-pointer"]
+    build_flags = env.get("BUILD_FLAGS", [])
+    env.Replace(BUILD_FLAGS=[f for f in build_flags if f not in flags_to_remove])
+
+    cxxflags = env.get("CXXFLAGS", [])
+    env.Replace(CXXFLAGS=[f for f in cxxflags if f not in flags_to_remove])
+
+    linkflags = env.get("LINKFLAGS", [])
+    env.Replace(LINKFLAGS=[f for f in linkflags if f not in flags_to_remove])

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "esp32:build": "cd esp32 && pio run && cd .. && npm run esp32:copy-firmware",
     "esp32:copy-firmware": "cd esp32 && python3 copy_firmware.py",
     "docs:setup": "cd public-docs && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt",
-    "docs:build": "./public-docs/build.sh",
+    "docs:build": "bash public-docs/build.sh",
     "docs:serve": "cd public-docs && .venv/bin/mkdocs serve"
   },
   "engines": {

--- a/scripts/check-code.sh
+++ b/scripts/check-code.sh
@@ -8,6 +8,9 @@
 
 set -e
 
+# Fix PlatformIO Unicode output on Windows (cp1252 can't encode checkmarks)
+export PYTHONIOENCODING=utf-8
+
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 # Cross-platform notification helper


### PR DESCRIPTION
- Add PYTHONIOENCODING=utf-8 to fix PlatformIO Unicode output on Windows (cp1252)
- Add _USE_MATH_DEFINES build flag for M_PI/M_PI_2 on MinGW
- Disable AddressSanitizer on Windows (MinGW lacks libasan) via pre-build script
- Use 'bash' prefix for docs:build npm script (Windows cmd doesn't understand './')

## Related Issue

Closes #

## Description

What does this PR do and why?

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] New game interceptor
- [ ] New LED effect
- [x] Build / CI changes

## How Has This Been Tested?

Describe the testing you performed.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have run `scripts/check-code.sh` and all checks pass
- [ ] I have run `pio run` (if ESP32 changes) and the build compiles
- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation where appropriate
- [ ] I have updated CHANGELOG.md
