### PR TITLE
Fix macOS damaged error and EMFILE test failures

### DIFF
--- a/rgfx-hub/assets/CLAUDE.md
+++ b/rgfx-hub/assets/CLAUDE.md
@@ -81,4 +81,4 @@ LED hardware definition files (JSON):
 
 ### Build Packaging
 
-Assets are bundled by `forge.config.js` via `extraResource`. Documentation is no longer bundled — it is hosted online at rgfx.io/docs. The macOS build is unsigned (no Apple Developer certificate) — `entitlements.mac.plist` exists at the hub root for future use if signing is added.
+Assets are bundled by `forge.config.js` via `extraResource`. Documentation is no longer bundled — it is hosted online at rgfx.io/docs. The macOS build uses a `postPackage` hook to re-sign with a valid ad-hoc signature (workaround for Electron Forge bug #3757). Full code signing requires an Apple Developer certificate — `entitlements.mac.plist` exists at the hub root for future use.

--- a/rgfx-hub/forge.config.js
+++ b/rgfx-hub/forge.config.js
@@ -48,6 +48,24 @@ const config = {
 
   rebuildConfig: {},
 
+  hooks: {
+    postPackage: async (_forgeConfig, options) => {
+      if (options.platform === "darwin") {
+        // Electron Forge produces a broken ad-hoc signature (forge#3757)
+        // which causes macOS to show "damaged" instead of "unidentified developer".
+        // Re-signing with a valid ad-hoc signature fixes this.
+        const { execSync } = require("child_process");
+        const appBundle = fs.readdirSync(options.outputPaths[0])
+          .find((f) => f.endsWith(".app"));
+        if (!appBundle) return;
+        const appPath = path.join(options.outputPaths[0], appBundle);
+        execSync(`codesign --force --deep --sign - "${appPath}"`, {
+          stdio: "inherit",
+        });
+      }
+    },
+  },
+
   makers: [
     new MakerSquirrel({
       setupIcon: "./assets/icons/icon.ico",

--- a/rgfx-hub/src/CLAUDE.md
+++ b/rgfx-hub/src/CLAUDE.md
@@ -51,6 +51,10 @@ Copy bundled defaults to `~/.rgfx/` on first run (skip existing files to preserv
 - `utils/firmware-paths.ts` — Firmware directory helpers: `getFirmwareDir`, `getFirmwareFilePath`
 - `utils/error-utils.ts` — `getErrorMessage` for safe error-to-string conversion
 
+## Import Conventions
+
+**Use deep imports for `@mui/icons-material`** — barrel imports cause EMFILE errors in vitest by resolving all ~7000 icon modules. Use `import FooIcon from '@mui/icons-material/Foo'` instead of `import { Foo as FooIcon } from '@mui/icons-material'`.
+
 ## Test Infrastructure
 
 Global test setup (`__tests__/setup.ts`) provides:

--- a/rgfx-hub/src/__tests__/components/super-button.test.tsx
+++ b/rgfx-hub/src/__tests__/components/super-button.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import SuperButton from '@/renderer/components/common/super-button';
-import { Star as StarIcon } from '@mui/icons-material';
+import StarIcon from '@mui/icons-material/Star';
 
 describe('SuperButton', () => {
   it('renders button with children text', () => {

--- a/rgfx-hub/src/renderer/components/CLAUDE.md
+++ b/rgfx-hub/src/renderer/components/CLAUDE.md
@@ -4,6 +4,18 @@
 
 This folder contains reusable React components for the RGFX Hub renderer process.
 
+## Import Convention
+
+**Use deep imports for `@mui/icons-material`** — barrel imports cause EMFILE errors during vitest runs by resolving all ~7000 icon modules at once.
+
+```tsx
+// Correct
+import DeleteIcon from '@mui/icons-material/Delete';
+
+// Wrong — causes EMFILE
+import { Delete as DeleteIcon } from '@mui/icons-material';
+```
+
 ---
 
 ## Layout Components

--- a/rgfx-hub/src/renderer/components/charts/telemetry-charts.tsx
+++ b/rgfx-hub/src/renderer/components/charts/telemetry-charts.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Typography, Divider, Stack, useColorScheme } from '@mui/material';
-import { Timeline as TimelineIcon } from '@mui/icons-material';
+import TimelineIcon from '@mui/icons-material/Timeline';
 import { useTelemetryHistoryStore } from '@/renderer/store/telemetry-history-store';
 import { formatBytes } from '@/renderer/utils/formatters';
 import { LineChart } from './line-chart';

--- a/rgfx-hub/src/renderer/components/common/__tests__/confirm-action-button.test.tsx
+++ b/rgfx-hub/src/renderer/components/common/__tests__/confirm-action-button.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Delete as DeleteIcon } from '@mui/icons-material';
+import DeleteIcon from '@mui/icons-material/Delete';
 import ConfirmActionButton from '../confirm-action-button';
 
 describe('ConfirmActionButton', () => {

--- a/rgfx-hub/src/renderer/components/common/__tests__/dialog-title-with-icon.test.tsx
+++ b/rgfx-hub/src/renderer/components/common/__tests__/dialog-title-with-icon.test.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { Dialog, IconButton } from '@mui/material';
-import { Warning as WarningIcon, Error as ErrorIcon, Close as CloseIcon } from '@mui/icons-material';
+import WarningIcon from '@mui/icons-material/Warning';
+import ErrorIcon from '@mui/icons-material/Error';
+import CloseIcon from '@mui/icons-material/Close';
 import { DialogTitleWithIcon } from '../dialog-title-with-icon';
 
 const renderWithDialog = (ui: React.ReactElement) => {

--- a/rgfx-hub/src/renderer/components/common/clear-all-effects-button.tsx
+++ b/rgfx-hub/src/renderer/components/common/clear-all-effects-button.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { Button } from '@mui/material';
-import { LayersClear as LayersClearIcon } from '@mui/icons-material';
+import LayersClearIcon from '@mui/icons-material/LayersClear';
 import { useDriverStore } from '../../store/driver-store';
 import { useUiStore } from '../../store/ui-store';
 

--- a/rgfx-hub/src/renderer/components/common/critical-error-modal.tsx
+++ b/rgfx-hub/src/renderer/components/common/critical-error-modal.tsx
@@ -10,11 +10,9 @@ import {
   IconButton,
   Tooltip,
 } from '@mui/material';
-import {
-  ErrorOutline as ErrorIcon,
-  FolderOpen as FolderIcon,
-  ContentCopy as CopyIcon,
-} from '@mui/icons-material';
+import ErrorIcon from '@mui/icons-material/ErrorOutline';
+import FolderIcon from '@mui/icons-material/FolderOpen';
+import CopyIcon from '@mui/icons-material/ContentCopy';
 import type { SystemError } from '@/types';
 import { DialogTitleWithIcon } from './dialog-title-with-icon';
 

--- a/rgfx-hub/src/renderer/components/common/directory-picker.tsx
+++ b/rgfx-hub/src/renderer/components/common/directory-picker.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IconButton, InputAdornment, SxProps, TextField, Theme } from '@mui/material';
-import { FolderOpen } from '@mui/icons-material';
+import FolderOpen from '@mui/icons-material/FolderOpen';
 
 interface DirectoryPickerProps {
   label: string;

--- a/rgfx-hub/src/renderer/components/driver/delete-driver-button.tsx
+++ b/rgfx-hub/src/renderer/components/driver/delete-driver-button.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Typography } from '@mui/material';
-import { Delete as DeleteIcon, Warning as WarningIcon } from '@mui/icons-material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import WarningIcon from '@mui/icons-material/Warning';
 import ConfirmActionButton from '../common/confirm-action-button';
 import type { DriverButtonProps } from './types';
 

--- a/rgfx-hub/src/renderer/components/driver/disable-driver-button.tsx
+++ b/rgfx-hub/src/renderer/components/driver/disable-driver-button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Block as BlockIcon, PlayArrow as PlayArrowIcon } from '@mui/icons-material';
+import BlockIcon from '@mui/icons-material/Block';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { useAsyncAction } from '../../hooks/use-async-action';
 import SuperButton from '../common/super-button';
 import type { DriverButtonProps } from './types';

--- a/rgfx-hub/src/renderer/components/driver/driver-card.tsx
+++ b/rgfx-hub/src/renderer/components/driver/driver-card.tsx
@@ -3,15 +3,13 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { Paper, Typography, Box, IconButton, Alert, Stack } from '@mui/material';
 import SuperButton from '../common/super-button';
 import DriverState from './driver-state';
-import {
-  Lightbulb as LightbulbIcon,
-  Speed as SpeedIcon,
-  Sensors as SensorsIcon,
-  ArrowBack as ArrowBackIcon,
-  Settings as SettingsIcon,
-  Description as DescriptionIcon,
-  Info as InfoIcon,
-} from '@mui/icons-material';
+import LightbulbIcon from '@mui/icons-material/Lightbulb';
+import SpeedIcon from '@mui/icons-material/Speed';
+import SensorsIcon from '@mui/icons-material/Sensors';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import SettingsIcon from '@mui/icons-material/Settings';
+import DescriptionIcon from '@mui/icons-material/Description';
+import InfoIcon from '@mui/icons-material/Info';
 import type { Driver } from '@/types';
 import InfoSection from '../common/info-section';
 import TestLedButton from './test-led-button';

--- a/rgfx-hub/src/renderer/components/driver/driver-state.tsx
+++ b/rgfx-hub/src/renderer/components/driver/driver-state.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, Chip, type ChipProps, CircularProgress, Tooltip, IconButton } from '@mui/material';
-import { Warning as WarningIcon } from '@mui/icons-material';
+import WarningIcon from '@mui/icons-material/Warning';
 import type { Driver, DriverState as DriverStateType } from '@/types';
 import { mapChipNameToVariant } from '@/schemas/firmware-manifest';
 

--- a/rgfx-hub/src/renderer/components/driver/reset-driver-button.tsx
+++ b/rgfx-hub/src/renderer/components/driver/reset-driver-button.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Typography } from '@mui/material';
-import { RestartAlt as RestartAltIcon, Warning as WarningIcon } from '@mui/icons-material';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import WarningIcon from '@mui/icons-material/Warning';
 import ConfirmActionButton from '../common/confirm-action-button';
 import type { DriverButtonProps } from './types';
 

--- a/rgfx-hub/src/renderer/components/driver/restart-driver-button.tsx
+++ b/rgfx-hub/src/renderer/components/driver/restart-driver-button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Typography } from '@mui/material';
-import { Refresh as RefreshIcon } from '@mui/icons-material';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import ConfirmActionButton from '../common/confirm-action-button';
 import type { DriverButtonProps } from './types';
 

--- a/rgfx-hub/src/renderer/components/driver/target-drivers-picker.tsx
+++ b/rgfx-hub/src/renderer/components/driver/target-drivers-picker.tsx
@@ -9,7 +9,7 @@ import {
   Popover,
   Chip,
 } from '@mui/material';
-import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import type { Driver } from '@/types';
 
 interface TargetDriversPickerProps {

--- a/rgfx-hub/src/renderer/components/driver/test-led-button.tsx
+++ b/rgfx-hub/src/renderer/components/driver/test-led-button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Science as ScienceIcon } from '@mui/icons-material';
+import ScienceIcon from '@mui/icons-material/Science';
 import SuperButton from '../common/super-button';
 import type { DriverButtonProps } from './types';
 import { usePendingWithTimeout } from '@/renderer/hooks/use-pending-with-timeout';

--- a/rgfx-hub/src/renderer/components/editors/unified-panel-editor.tsx
+++ b/rgfx-hub/src/renderer/components/editors/unified-panel-editor.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Box, Typography, Button, Paper, TextField, Stack } from '@mui/material';
-import { GridView as GridIcon, Clear as ClearIcon } from '@mui/icons-material';
+import GridIcon from '@mui/icons-material/GridView';
+import ClearIcon from '@mui/icons-material/Clear';
 import {
   DndContext,
   closestCenter,

--- a/rgfx-hub/src/renderer/components/firmware/flash-result-dialog.tsx
+++ b/rgfx-hub/src/renderer/components/firmware/flash-result-dialog.tsx
@@ -6,7 +6,8 @@ import {
   Typography,
   Button,
 } from '@mui/material';
-import { CheckCircle as SuccessIcon, Error as ErrorIcon } from '@mui/icons-material';
+import SuccessIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
 import { DialogTitleWithIcon } from '../common/dialog-title-with-icon';
 import type { FlashMethod } from '../../hooks/use-flash-state';
 

--- a/rgfx-hub/src/renderer/components/firmware/wifi-config-button.tsx
+++ b/rgfx-hub/src/renderer/components/firmware/wifi-config-button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SettingsInputAntenna as ConfigWifiIcon } from '@mui/icons-material';
+import ConfigWifiIcon from '@mui/icons-material/SettingsInputAntenna';
 import SuperButton from '../common/super-button';
 import WifiConfigDialog from './wifi-config-dialog';
 import { sendWifiCommandToPort } from '@/renderer/utils/serial-wifi';

--- a/rgfx-hub/src/renderer/components/firmware/wifi-config-ota-button.tsx
+++ b/rgfx-hub/src/renderer/components/firmware/wifi-config-ota-button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SettingsInputAntenna as ConfigWifiIcon } from '@mui/icons-material';
+import ConfigWifiIcon from '@mui/icons-material/SettingsInputAntenna';
 import SuperButton from '../common/super-button';
 import WifiConfigDialog from './wifi-config-dialog';
 import { plural } from '@/renderer/utils/formatters';

--- a/rgfx-hub/src/renderer/components/layout/page-title.tsx
+++ b/rgfx-hub/src/renderer/components/layout/page-title.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, IconButton, Typography } from '@mui/material';
-import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 interface PageTitleProps {
   icon?: ReactNode;

--- a/rgfx-hub/src/renderer/components/layout/sidebar-nav.tsx
+++ b/rgfx-hub/src/renderer/components/layout/sidebar-nav.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import { Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
-import {
-  Dashboard as DashboardIcon,
-  Usb as UsbIcon,
-  Monitor as MonitorIcon,
-  Memory as FirmwareIcon,
-  Science as ScienceIcon,
-  Terminal as TerminalIcon,
-  Settings as SettingsIcon,
-  Info as InfoIcon,
-  SportsEsports as GamesIcon,
-  HelpOutline as HelpIcon,
-} from '@mui/icons-material';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import UsbIcon from '@mui/icons-material/Usb';
+import MonitorIcon from '@mui/icons-material/Monitor';
+import FirmwareIcon from '@mui/icons-material/Memory';
+import ScienceIcon from '@mui/icons-material/Science';
+import TerminalIcon from '@mui/icons-material/Terminal';
+import SettingsIcon from '@mui/icons-material/Settings';
+import InfoIcon from '@mui/icons-material/Info';
+import GamesIcon from '@mui/icons-material/SportsEsports';
+import HelpIcon from '@mui/icons-material/HelpOutline';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 interface NavItem {

--- a/rgfx-hub/src/renderer/components/settings/appearance-section.tsx
+++ b/rgfx-hub/src/renderer/components/settings/appearance-section.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { ToggleButton, ToggleButtonGroup } from '@mui/material';
-import { Brightness4, Brightness7, SettingsBrightness } from '@mui/icons-material';
+import Brightness4 from '@mui/icons-material/Brightness4';
+import Brightness7 from '@mui/icons-material/Brightness7';
+import SettingsBrightness from '@mui/icons-material/SettingsBrightness';
 import { useColorScheme } from '@mui/material/styles';
 import { SettingsSection } from './settings-section';
 

--- a/rgfx-hub/src/renderer/components/settings/backup-section.tsx
+++ b/rgfx-hub/src/renderer/components/settings/backup-section.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Stack, Typography } from '@mui/material';
-import { Archive as ArchiveIcon } from '@mui/icons-material';
+import ArchiveIcon from '@mui/icons-material/Archive';
 import SuperButton from '../common/super-button';
 import { notify } from '../../store/notification-store';
 import { SettingsSection } from './settings-section';

--- a/rgfx-hub/src/renderer/components/settings/directories-section.tsx
+++ b/rgfx-hub/src/renderer/components/settings/directories-section.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Stack } from '@mui/material';
-import { Save } from '@mui/icons-material';
+import Save from '@mui/icons-material/Save';
 import { useUiStore } from '../../store/ui-store';
 import { useAppInfoStore } from '../../store/app-info-store';
 import { notify } from '../../store/notification-store';

--- a/rgfx-hub/src/renderer/components/settings/logs-section.tsx
+++ b/rgfx-hub/src/renderer/components/settings/logs-section.tsx
@@ -12,7 +12,7 @@ import {
   TableRow,
   Tooltip,
 } from '@mui/material';
-import { Delete as DeleteIcon } from '@mui/icons-material';
+import DeleteIcon from '@mui/icons-material/Delete';
 import ConfirmActionButton from '../common/confirm-action-button';
 import { notify } from '../../store/notification-store';
 import { formatBytes } from '../../utils/formatters';

--- a/rgfx-hub/src/renderer/components/simulator/simulator-row.tsx
+++ b/rgfx-hub/src/renderer/components/simulator/simulator-row.tsx
@@ -7,7 +7,7 @@ import {
   Select,
   MenuItem,
 } from '@mui/material';
-import { PlayArrow as PlayArrowIcon } from '@mui/icons-material';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { debounce } from 'lodash-es';
 import { useUiStore, SimulatorAutoInterval } from '../../store/ui-store';
 import SuperButton from '../common/super-button';

--- a/rgfx-hub/src/renderer/pages/CLAUDE.md
+++ b/rgfx-hub/src/renderer/pages/CLAUDE.md
@@ -4,6 +4,8 @@
 
 This folder contains the main page components for the RGFX Hub application. Each page is a React functional component that renders a full-page view accessible via React Router.
 
+**Import convention:** Use deep imports for `@mui/icons-material` (e.g., `import SaveIcon from '@mui/icons-material/Save'`). Barrel imports cause EMFILE errors in vitest.
+
 ---
 
 ## Pages

--- a/rgfx-hub/src/renderer/pages/about-page.tsx
+++ b/rgfx-hub/src/renderer/pages/about-page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Typography, Box, Paper, Link, Stack } from '@mui/material';
-import { Info as InfoIcon } from '@mui/icons-material';
+import InfoIcon from '@mui/icons-material/Info';
 import { PageTitle } from '../components/layout/page-title';
 import { useAppInfoStore } from '../store/app-info-store';
 

--- a/rgfx-hub/src/renderer/pages/driver-config-page.tsx
+++ b/rgfx-hub/src/renderer/pages/driver-config-page.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Box, Paper, Typography, Button } from '@mui/material';
-import { Save as SaveIcon } from '@mui/icons-material';
+import SaveIcon from '@mui/icons-material/Save';
 import { PageTitle } from '../components/layout/page-title';
 import { useDriverStore } from '../store/driver-store';
 import { notify } from '../store/notification-store';

--- a/rgfx-hub/src/renderer/pages/drivers-page.tsx
+++ b/rgfx-hub/src/renderer/pages/drivers-page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Paper } from '@mui/material';
-import { Usb as UsbIcon } from '@mui/icons-material';
+import UsbIcon from '@mui/icons-material/Usb';
 import { useDriverStore } from '../store/driver-store';
 import DriverListTable from '../components/driver/driver-list-table';
 import { PageTitle } from '../components/layout/page-title';

--- a/rgfx-hub/src/renderer/pages/effects-playground-page.tsx
+++ b/rgfx-hub/src/renderer/pages/effects-playground-page.tsx
@@ -15,13 +15,11 @@ import {
   Tooltip,
   Button,
 } from '@mui/material';
-import {
-  Science as ScienceIcon,
-  ContentCopy as CopyIcon,
-  RestartAlt as ResetIcon,
-  Shuffle as ShuffleIcon,
-  Palette as PaletteIcon,
-} from '@mui/icons-material';
+import ScienceIcon from '@mui/icons-material/Science';
+import CopyIcon from '@mui/icons-material/ContentCopy';
+import ResetIcon from '@mui/icons-material/RestartAlt';
+import ShuffleIcon from '@mui/icons-material/Shuffle';
+import PaletteIcon from '@mui/icons-material/Palette';
 import { PageTitle } from '../components/layout/page-title';
 import { TargetDriversPicker } from '../components/driver/target-drivers-picker';
 import SuperButton from '../components/common/super-button';

--- a/rgfx-hub/src/renderer/pages/event-monitor-page.tsx
+++ b/rgfx-hub/src/renderer/pages/event-monitor-page.tsx
@@ -12,11 +12,9 @@ import {
   DialogActions,
   Stack,
 } from '@mui/material';
-import {
-  Monitor as MonitorIcon,
-  Refresh as RefreshIcon,
-  Warning as WarningIcon,
-} from '@mui/icons-material';
+import MonitorIcon from '@mui/icons-material/Monitor';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import WarningIcon from '@mui/icons-material/Warning';
 import { useEventStore } from '../store/event-store';
 import { PageTitle } from '../components/layout/page-title';
 import { useSortableTable } from '../hooks/use-sortable-table';

--- a/rgfx-hub/src/renderer/pages/firmware-page.tsx
+++ b/rgfx-hub/src/renderer/pages/firmware-page.tsx
@@ -17,12 +17,10 @@ import WifiConfigButton from '../components/firmware/wifi-config-button';
 import WifiConfigOtaButton from '../components/firmware/wifi-config-ota-button';
 import { TargetDriversPicker } from '../components/driver/target-drivers-picker';
 import SuperButton from '../components/common/super-button';
-import {
-  Upload as FlashIcon,
-  Usb as UsbIcon,
-  Wifi as WifiIcon,
-  Memory as FirmwareIcon,
-} from '@mui/icons-material';
+import FlashIcon from '@mui/icons-material/Upload';
+import UsbIcon from '@mui/icons-material/Usb';
+import WifiIcon from '@mui/icons-material/Wifi';
+import FirmwareIcon from '@mui/icons-material/Memory';
 import { PageTitle } from '../components/layout/page-title';
 import { useDriverStore } from '../store/driver-store';
 import { useSystemStatusStore } from '../store/system-status-store';

--- a/rgfx-hub/src/renderer/pages/games-page.tsx
+++ b/rgfx-hub/src/renderer/pages/games-page.tsx
@@ -14,7 +14,7 @@ import {
   Alert,
   Stack,
 } from '@mui/material';
-import { SportsEsports as GamesIcon } from '@mui/icons-material';
+import GamesIcon from '@mui/icons-material/SportsEsports';
 import { Link as RouterLink } from 'react-router-dom';
 import type { GameInfo } from '@/types';
 import { PageTitle } from '../components/layout/page-title';

--- a/rgfx-hub/src/renderer/pages/help-page.tsx
+++ b/rgfx-hub/src/renderer/pages/help-page.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { Typography, Box, Paper, Button } from '@mui/material';
-import {
-  HelpOutline as HelpIcon,
-  MenuBook as DocsIcon,
-} from '@mui/icons-material';
+import HelpIcon from '@mui/icons-material/HelpOutline';
+import DocsIcon from '@mui/icons-material/MenuBook';
 import { PageTitle } from '../components/layout/page-title';
 
 const DOCS_URL = 'https://rgfx.io/docs';

--- a/rgfx-hub/src/renderer/pages/settings-page.tsx
+++ b/rgfx-hub/src/renderer/pages/settings-page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Stack } from '@mui/material';
-import { Settings as SettingsIcon } from '@mui/icons-material';
+import SettingsIcon from '@mui/icons-material/Settings';
 import { PageTitle } from '../components/layout/page-title';
 import {
   AppearanceSection,

--- a/rgfx-hub/src/renderer/pages/simulator-page.tsx
+++ b/rgfx-hub/src/renderer/pages/simulator-page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Paper, Stack } from '@mui/material';
-import { Terminal as TerminalIcon } from '@mui/icons-material';
+import TerminalIcon from '@mui/icons-material/Terminal';
 import { SIMULATOR_ROW_COUNT } from '@/config/constants';
 import { PageTitle } from '../components/layout/page-title';
 import { ClearAllEffectsButton } from '../components/common/clear-all-effects-button';

--- a/rgfx-hub/src/renderer/pages/system-status-page.tsx
+++ b/rgfx-hub/src/renderer/pages/system-status-page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Alert, Box, Paper, Stack } from '@mui/material';
-import { Dashboard as DashboardIcon } from '@mui/icons-material';
+import DashboardIcon from '@mui/icons-material/Dashboard';
 import SystemStatus from '../components/system/system-status';
 import { SystemErrors } from '../components/system/system-errors';
 import { EventsRateChart } from '../components/charts/events-rate-chart';


### PR DESCRIPTION
## Summary
- Add `postPackage` hook in `forge.config.js` to re-sign the macOS app with a valid ad-hoc signature after packaging, fixing Electron Forge bug [#3757](https://github.com/electron/forge/issues/3757) that caused macOS Gatekeeper to show "damaged and can't be opened" instead of "unidentified developer"
- Replace `@mui/icons-material` barrel imports with deep imports across 37 files to prevent EMFILE ("too many open files") errors during vitest runs — barrel imports caused vitest to resolve all ~7000 icon modules at once

## Test plan
- [x] Local `npm run make` produces a valid DMG with correct ad-hoc signature (`codesign --verify --deep --strict` passes)
- [x] All 190 test files pass (2917 tests, 0 failures)
- [x] `scripts/check-code.sh` passes (typecheck, lint, unused exports, tests, depcheck, licenses)
- [ ] CI passes (Hub Tests + Driver Tests)
- [ ] Download DMG from next release and verify macOS shows "unidentified developer" instead of "damaged"

🤖 Generated with [Claude Code](https://claude.com/claude-code)