### PR TITLE
Add macOS code signing and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,12 @@ jobs:
       - name: Build installer
         run: npm run make
         working-directory: rgfx-hub
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Rename installer
         run: |

--- a/rgfx-hub/assets/CLAUDE.md
+++ b/rgfx-hub/assets/CLAUDE.md
@@ -81,4 +81,4 @@ LED hardware definition files (JSON):
 
 ### Build Packaging
 
-Assets are bundled by `forge.config.js` via `extraResource`. Documentation is no longer bundled — it is hosted online at rgfx.io/docs. The macOS build uses a `postPackage` hook to re-sign with a valid ad-hoc signature (workaround for Electron Forge bug #3757). Full code signing requires an Apple Developer certificate — `entitlements.mac.plist` exists at the hub root for future use.
+Assets are bundled by `forge.config.js` via `extraResource`. Documentation is no longer bundled — it is hosted online at rgfx.io/docs. The macOS build uses Apple Developer ID code signing and notarization via `osxSign` and `osxNotarize` in `forge.config.js`. Signing secrets are passed as environment variables in the CI release workflow. The entitlements file (`entitlements.mac.plist`) grants JIT, unsigned memory, dyld env vars, library validation bypass, and network access required by Electron.

--- a/rgfx-hub/entitlements.mac.plist
+++ b/rgfx-hub/entitlements.mac.plist
@@ -6,6 +6,8 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
     <key>com.apple.security.network.client</key>

--- a/rgfx-hub/forge.config.js
+++ b/rgfx-hub/forge.config.js
@@ -18,6 +18,21 @@ const config = {
       NSLocalNetworkUsageDescription: "RGFX Hub needs local network access to communicate with LED drivers via UDP and MQTT.",
       NSBonjourServices: ["_mqtt._tcp", "_rgfx._udp"],
     },
+    osxSign: {
+      optionsForFile: () => ({
+        entitlements: "./entitlements.mac.plist",
+        entitlementsInherit: "./entitlements.mac.plist",
+      }),
+    },
+    ...(process.env.APPLE_ID && process.env.APPLE_ID_PASSWORD && process.env.APPLE_TEAM_ID
+      ? {
+          osxNotarize: {
+            appleId: process.env.APPLE_ID,
+            appleIdPassword: process.env.APPLE_ID_PASSWORD,
+            teamId: process.env.APPLE_TEAM_ID,
+          },
+        }
+      : {}),
     extraResource: [
       "./assets/transformers",
       "./assets/interceptors",
@@ -47,24 +62,6 @@ const config = {
   },
 
   rebuildConfig: {},
-
-  hooks: {
-    postPackage: async (_forgeConfig, options) => {
-      if (options.platform === "darwin") {
-        // Electron Forge produces a broken ad-hoc signature (forge#3757)
-        // which causes macOS to show "damaged" instead of "unidentified developer".
-        // Re-signing with a valid ad-hoc signature fixes this.
-        const { execSync } = require("child_process");
-        const appBundle = fs.readdirSync(options.outputPaths[0])
-          .find((f) => f.endsWith(".app"));
-        if (!appBundle) return;
-        const appPath = path.join(options.outputPaths[0], appBundle);
-        execSync(`codesign --force --deep --sign - "${appPath}"`, {
-          stdio: "inherit",
-        });
-      }
-    },
-  },
 
   makers: [
     new MakerSquirrel({


### PR DESCRIPTION
## Summary
- Configure Electron Forge with `osxSign` and `osxNotarize` for Apple Developer ID code signing
- Pass signing secrets (`CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`) to the CI macOS build step
- Remove the ad-hoc `postPackage` re-signing hook (no longer needed with real signing)
- Add `allow-dyld-environment-variables` entitlement for Electron compatibility

## Test plan
- [ ] Verify local `npm run make` still produces an unsigned DMG without errors (notarization is skipped when env vars are absent)
- [ ] Trigger a release workflow and confirm signing + notarization output in macOS build logs
- [ ] Verify the resulting DMG installs without Gatekeeper warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)