### PR TITLE
Rename app productName to RGFX Hub

### DIFF
--- a/rgfx-hub/package.json
+++ b/rgfx-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rgfx-hub",
-  "productName": "rgfx-hub",
+  "productName": "RGFX Hub",
   "version": "1.0.9",
   "description": "Visual effects controller for retro arcade games",
   "main": ".vite/build/main.js",


### PR DESCRIPTION
## Summary
- Changes `productName` in package.json from `rgfx-hub` to `RGFX Hub`
- Affects the app name shown in macOS DMG, Windows installer, title bar, and taskbar

## Test plan
- [ ] Verify macOS DMG shows "RGFX Hub" as app name
- [ ] Verify Windows installer/exe shows "RGFX Hub"

🤖 Generated with [Claude Code](https://claude.com/claude-code)