### PR TITLE
Fix release workflow unstaged package-lock.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           VERSION="${TAG#v}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add rgfx-hub/package.json
+          git add rgfx-hub/package.json package-lock.json
           git commit -m "Bump hub version to ${VERSION}"
           git tag "$TAG"
           git push origin main


### PR DESCRIPTION
## Summary
- Stage `package-lock.json` alongside `package.json` in the release version bump commit
- Fixes failure when `npm install` updates the lockfile (e.g., after productName change)

## Test plan
- [ ] Re-run release workflow as v1.0.9 and verify the prepare step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)