### PR TITLE
Fix macOS code signing by importing cert into keychain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,12 +161,25 @@ jobs:
       - name: Inject Hub version
         run: node scripts/inject-version-hub.js
 
+      - name: Import signing certificate
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          echo -n "$CSC_LINK" | base64 --decode -o $CERTIFICATE_PATH
+          security create-keychain -p "" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "" $KEYCHAIN_PATH
+          security import $CERTIFICATE_PATH -P "$CSC_KEY_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "" $KEYCHAIN_PATH
+          security list-keychains -d user -s $KEYCHAIN_PATH login.keychain-db
+
       - name: Build installer
         run: npm run make
         working-directory: rgfx-hub
         env:
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -186,6 +199,10 @@ jobs:
         with:
           name: hub-installer-macos
           path: ${{ env.ARTIFACT_NAME }}
+
+      - name: Clean up keychain
+        if: always()
+        run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
 
   build-hub-windows:
     name: Build Hub (Windows)


### PR DESCRIPTION
## Summary

- **Root cause:** `@electron/osx-sign` (used by Electron Forge) finds signing identities in the macOS keychain, not via `CSC_LINK` env var (that's an `electron-builder` convention). The certificate was never imported, so apps shipped adhoc-signed. A newer `@electron/notarize` now validates the signature pre-notarization, catching the issue.
- Add a workflow step to decode the base64 p12 from `CSC_LINK`, import it into a temporary keychain, and make it available for codesigning
- Clean up the temporary keychain after the job completes

## Test plan

- [ ] Trigger a release workflow run and verify the macOS build passes
- [ ] Check build log for `Signature=` showing Developer ID identity (not `adhoc`)
- [ ] Verify the DMG artifact is produced and uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)