### PR TITLE
Treat dev firmware builds as always newer for update banner

### DIFF
--- a/rgfx-hub/src/services/CLAUDE.md
+++ b/rgfx-hub/src/services/CLAUDE.md
@@ -17,7 +17,7 @@ Singleton service that reads firmware versions from `manifest.json` in the bundl
 Key methods:
 - `getVersions()`: returns `Record<SupportedChip, string>` with all chip versions
 - `getVersionForChip(chipType)`: returns version string for a specific chip type
-- `needsUpdate(driverVersion, chipType)`: uses `semver.gt()` to check if bundled firmware is strictly newer than the driver's version. Prevents false "downgrade" warnings when running dev prerelease builds.
+- `needsUpdate(driverVersion, chipType)`: Dev builds (version contains `-dev`) are always considered newer than what the driver is running (unless exact match), so the firmware update banner always appears during development. Release builds use `semver.gt()` for strict comparison.
 
 This per-chip version tracking prevents false "update needed" notifications when only one chip variant has been rebuilt.
 

--- a/rgfx-hub/src/services/__tests__/firmware-version-service.test.ts
+++ b/rgfx-hub/src/services/__tests__/firmware-version-service.test.ts
@@ -139,7 +139,7 @@ describe('FirmwareVersionService', () => {
       expect(firmwareVersionService.needsUpdate('1.3.0', 'ESP32')).toBe(false);
     });
 
-    it('should return false when bundled is a dev prerelease of same version', async () => {
+    it('should always flag update when bundled is a dev build', async () => {
       const devManifest = {
         ...validManifest,
         variants: {
@@ -154,10 +154,11 @@ describe('FirmwareVersionService', () => {
 
       const { firmwareVersionService } = await import('../firmware-version-service.js');
 
-      // Bundled 1.0.12-dev < driver 1.0.13 — no update
-      expect(firmwareVersionService.needsUpdate('1.0.13', 'ESP32')).toBe(false);
-      // Bundled 1.0.12-dev < driver 1.0.12 — no update (prerelease < release)
-      expect(firmwareVersionService.needsUpdate('1.0.12', 'ESP32')).toBe(false);
+      // Dev builds are always considered newer (freshly built firmware)
+      expect(firmwareVersionService.needsUpdate('1.0.13', 'ESP32')).toBe(true);
+      expect(firmwareVersionService.needsUpdate('1.0.12', 'ESP32')).toBe(true);
+      // Unless the version matches exactly (already flashed this build)
+      expect(firmwareVersionService.needsUpdate('1.0.12-dev+c6c2a4a8', 'ESP32')).toBe(false);
     });
 
     it('should compare against correct chip variant', async () => {

--- a/rgfx-hub/src/services/firmware-version-service.ts
+++ b/rgfx-hub/src/services/firmware-version-service.ts
@@ -88,7 +88,13 @@ class FirmwareVersionService {
       return false;
     }
 
-    // Only flag update when bundled firmware is strictly newer than what the driver is running
+    // Dev builds (e.g. 1.0.13-dev+hash) are always considered newer — they represent
+    // freshly built firmware that should always be flashable during development
+    if (targetVersion.includes('-dev')) {
+      return targetVersion !== driverVersion;
+    }
+
+    // Release builds: only flag update when bundled firmware is strictly newer
     const target = semver.parse(semver.clean(targetVersion) ?? targetVersion);
     const driver = semver.parse(semver.clean(driverVersion) ?? driverVersion);
 


### PR DESCRIPTION
## Summary
- Dev builds (version contains `-dev`) are now always considered newer than what the driver is running (unless exact match), so the firmware update banner always appears during development
- Release builds continue to use strict `semver.gt()` comparison
- Updated tests to reflect the new dev build behavior

## Test plan
- [ ] Verify dev firmware builds show the update banner for any non-matching driver version
- [ ] Verify exact version match (e.g. `1.0.12-dev+hash` == `1.0.12-dev+hash`) does not show update banner
- [ ] Verify release builds still use strict semver comparison
- [ ] CI passes (Hub Tests + Driver Tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)