### PR TITLE
Fix deploy-pages version: v5 does not exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v4
 
   create-release:
     name: Create Release


### PR DESCRIPTION
## Summary
- Reverts `actions/deploy-pages` from `@v5` back to `@v4` — v5 has not been released
- This was incorrectly bumped in #50 and caused the Deploy Pages job to fail in the release workflow

## Test plan
- [ ] Verify PR checks pass
- [ ] Run release workflow and confirm Deploy Pages job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)