### PR TITLE
Fix Windows installer rename step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,12 @@ jobs:
         run: |
           $tag = "${{ needs.prepare.outputs.tag }}"
           $version = $tag.TrimStart("v")
-          $exe = Get-ChildItem -Path "rgfx-hub/out" -Filter "*.exe" -Recurse | Select-Object -First 1
+          Write-Host "Contents of rgfx-hub/out:"
+          Get-ChildItem -Path "rgfx-hub/out" -Recurse | ForEach-Object { Write-Host $_.FullName }
+          $exe = Get-ChildItem -Path "rgfx-hub/out" -Filter "*.exe" -Recurse | Where-Object { $_.Name -match "Setup" } | Select-Object -First 1
+          if (-not $exe) {
+            $exe = Get-ChildItem -Path "rgfx-hub/out" -Filter "*.exe" -Recurse | Select-Object -First 1
+          }
           $dest = "rgfx-${version}-windows-x64.exe"
           Copy-Item $exe.FullName $dest
           "ARTIFACT_NAME=$dest" | Out-File -FilePath $env:GITHUB_ENV -Append


### PR DESCRIPTION
## Summary

- The Windows "Rename installer" step fails because electron-builder NSIS output location differs from the old Forge/Squirrel layout
- Adds directory listing to diagnose the exact output path
- Prefers the NSIS "Setup" exe over the unpacked app binary

## Context

Build and **signing both succeeded** in the previous run — only the post-build rename step failed.

## Test plan

- [ ] Release workflow produces directory listing showing actual output files
- [ ] Rename step finds and copies the correct installer exe

🤖 Generated with [Claude Code](https://claude.com/claude-code)