### PR TITLE
Fix renderer build output path causing blank window

### DIFF
--- a/rgfx-hub/src/renderer/vite.renderer.config.ts
+++ b/rgfx-hub/src/renderer/vite.renderer.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: '../../dist/renderer/main_window',
+    outDir: 'dist/renderer/main_window',
     emptyOutDir: true,
   },
 });


### PR DESCRIPTION
## Summary

- Fix `outDir` in renderer vite config from `../../dist/renderer/main_window` to `dist/renderer/main_window`
- Vite resolves `outDir` relative to project root (`process.cwd()`), not the config file location — the old path resolved **outside** the project, so electron-builder never packaged the renderer into the asar
- This caused a blank window (`ERR_FILE_NOT_FOUND`) in all production builds (both Windows and macOS)

## Test plan

- [x] `npm run build` produces `dist/renderer/main_window/index.html`
- [x] All 2952 tests pass
- [x] Typecheck, lint, unused deps checks pass
- [ ] Package locally and verify the asar contains renderer files
- [ ] Install and verify the app loads (not blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)