### PR TITLE
Add DMG code signing to macOS release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,12 +183,11 @@ jobs:
       - name: Sign DMG
         run: |
           DMG=$(find rgfx-hub/out -name "*.dmg" | head -1)
-          echo "Signing $DMG..."
-          codesign --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
-            --options runtime "$DMG"
+          IDENTITY=$(security find-identity -v -p codesigning | grep "$APPLE_TEAM_ID" | head -1 | awk -F'"' '{print $2}')
+          echo "Signing $DMG with identity: $IDENTITY"
+          codesign --sign "$IDENTITY" --options runtime "$DMG"
           codesign --verify --strict "$DMG"
         env:
-          APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       # TODO: Re-enable once Apple notarization is confirmed working


### PR DESCRIPTION
## Summary
- electron-builder signs the `.app` inside the DMG but not the DMG itself, causing Apple notarization submissions to hang at "In Progress" indefinitely
- Adds a "Sign DMG" step after the build that signs with Developer ID and hardened runtime
- Updated the commented-out notarization block with `spctl --assess` verification for when notarization is re-enabled

## Prerequisites
- `APPLE_TEAM_NAME` secret must be added to the repo (the human-readable name on the Developer ID certificate)
- `APPLE_TEAM_ID` secret already exists

## Test plan
- [ ] Run a release build and verify the DMG is signed (`codesign -dvvv <dmg>`)
- [ ] Manually submit signed DMG to notarization and confirm it no longer hangs
- [ ] Once confirmed, uncomment the notarize-and-staple block in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)