### PR TITLE
Remove mspacman from rom_map

### DIFF
--- a/rgfx-hub/assets/interceptors/rom_map.json
+++ b/rgfx-hub/assets/interceptors/rom_map.json
@@ -1,5 +1,4 @@
 {
-  "pacman": ["mspacman"],
   "defender": ["defenderg", "defenderb", "defenderw"],
   "outrun": ["outruna", "outrunb"],
   "sharrier": ["sharrier1", "sharrierj"],


### PR DESCRIPTION
## Summary
- Remove Ms. Pac-Man (`mspacman`) alias from `rom_map.json` — the pacman transformer does not work for Ms. Pac-Man
- Remove the now-empty `pacman` entry entirely from the ROM map

## Test plan
- [ ] Verify Pac-Man still loads its interceptor/transformer correctly (no rom_map entry needed — convention-based loading)
- [ ] Verify Ms. Pac-Man no longer attempts to use the pacman transformer

🤖 Generated with [Claude Code](https://claude.com/claude-code)