### PR TITLE
Fix orphan interceptors showing in Games table

### DIFF
--- a/rgfx-hub/src/renderer/pages/__tests__/games-page.test.tsx
+++ b/rgfx-hub/src/renderer/pages/__tests__/games-page.test.tsx
@@ -119,11 +119,14 @@ describe('GamesPage', () => {
     });
 
     it('does not show launch button when ROM is missing (orphan interceptor)', async () => {
-      mockRgfx.listGames.mockResolvedValue([ORPHAN_INTERCEPTOR]);
+      mockRgfx.listGames.mockResolvedValue([FULL_GAME, ORPHAN_INTERCEPTOR]);
       renderPage();
+      await disableHideUnconfigured();
 
       await screen.findByText('galaga_rgfx.lua');
-      expect(screen.queryByRole('button', { name: /Launch/ })).toBeNull();
+      const launchButtons = screen.getAllByRole('button', { name: /Launch/ });
+      // Only pacman should have a launch button, not galaga (no ROM)
+      expect(launchButtons).toHaveLength(1);
     });
 
     it('calls launchMame with ROM name stripped of extension', async () => {
@@ -142,6 +145,13 @@ describe('GamesPage', () => {
       // Games missing interceptor or transformer are hidden
       expect(screen.queryByText('donkeykong_rgfx.lua')).toBeNull();
       expect(screen.queryByText('frogger.js')).toBeNull();
+    });
+
+    it('hides orphan interceptors (no ROM) when hide unconfigured is on', async () => {
+      renderPage();
+
+      await screen.findByText('pacman_rgfx.lua');
+      expect(screen.queryByText('galaga_rgfx.lua')).toBeNull();
     });
   });
 

--- a/rgfx-hub/src/renderer/pages/games-page.tsx
+++ b/rgfx-hub/src/renderer/pages/games-page.tsx
@@ -78,7 +78,9 @@ const GamesPage: React.FC = () => {
   };
 
   const isConfigured = (game: GameInfo) =>
-    Boolean(game.interceptorName && game.transformerName);
+    hasMameRomsDirectory
+      ? Boolean(game.romName && game.interceptorName && game.transformerName)
+      : Boolean(game.interceptorName && game.transformerName);
 
   const filteredGames = hideUnconfigured ? games.filter(isConfigured) : games;
 


### PR DESCRIPTION
## Summary
- Orphan interceptors (no matching ROM file) were appearing in the Games table with "Hide unconfigured" enabled, showing rows with no Launch button
- `isConfigured` now requires `romName` when ROMs directory is configured, filtering out orphan entries
- Without ROMs directory, original behavior preserved (interceptor + transformer only)

## Test plan
- [x] New test: orphan interceptors hidden when "Hide unconfigured" is on
- [x] Updated test: orphan interceptor row has no Launch button when filter is off
- [x] All existing games-page tests pass
- [x] `scripts/check-code.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)