### PR TITLE
Re-enable macOS notarization in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
     needs: [prepare, build-driver]
     if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.build-driver.result == 'success' }}
     runs-on: macos-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v5
@@ -190,24 +191,24 @@ jobs:
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
-      # TODO: Re-enable once Apple notarization is confirmed working
-      # - name: Notarize and staple
-      #   env:
-      #     APPLE_ID: ${{ secrets.APPLE_ID }}
-      #     APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-      #     APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      #   run: |
-      #     DMG=$(find rgfx-hub/out -name "*.dmg" | head -1)
-      #     echo "Submitting $DMG for notarization..."
-      #     xcrun notarytool submit "$DMG" \
-      #       --apple-id "$APPLE_ID" \
-      #       --password "$APPLE_ID_PASSWORD" \
-      #       --team-id "$APPLE_TEAM_ID" \
-      #       --wait --timeout 30m
-      #     echo "Stapling notarization ticket..."
-      #     xcrun stapler staple "$DMG"
-      #     echo "Verifying notarization..."
-      #     xcrun spctl --assess --type open --context context:primary-signature --verbose=2 "$DMG"
+      - name: Notarize and staple
+        continue-on-error: true
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          DMG=$(find rgfx-hub/out -name "*.dmg" | head -1)
+          echo "Submitting $DMG for notarization..."
+          xcrun notarytool submit "$DMG" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait --timeout 20m
+          echo "Stapling notarization ticket..."
+          xcrun stapler staple "$DMG"
+          echo "Verifying notarization..."
+          xcrun spctl --assess --type open --context context:primary-signature --verbose=2 "$DMG"
 
       - name: Rename installer
         run: |


### PR DESCRIPTION
## Summary
- Re-enables the macOS notarization step that was disabled while Apple's service was unreliable
- Adds `timeout-minutes: 30` to the macOS build job to cap credit burn
- Adds `continue-on-error: true` so the DMG artifact is still uploaded if notarization stalls
- Uses `--timeout 20m` on `notarytool` (within the 30-min job cap)

## Test plan
- [ ] Trigger a release workflow run and verify notarization succeeds
- [ ] Confirm DMG passes `spctl --assess` after download

🤖 Generated with [Claude Code](https://claude.com/claude-code)