### PR TITLE
Replace git-based date with release date in docs footer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
             fs.writeFileSync('rgfx-hub/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
           sed -i 's/^copyright: .*/copyright: "RGFX v'"${VERSION}"'"/' public-docs/mkdocs.yml
+          RELEASE_DATE=$(date -u +"%B %-d, %Y")
+          sed -i 's/^  release_date: .*/  release_date: "'"${RELEASE_DATE}"'"/' public-docs/mkdocs.yml
 
       - name: Commit and tag
         id: push

--- a/public-docs/docs/CLAUDE.md
+++ b/public-docs/docs/CLAUDE.md
@@ -72,10 +72,10 @@ Never hardcode `~/.rgfx` paths. Use "config directory" with a link to `getting-s
 
 The docs footer is customized via template overrides in `public-docs/overrides/partials/`:
 
-- `copyright.html` — Renders the version string (from `copyright` in `mkdocs.yml`), the per-page last-updated date, and the "Made with Material for MkDocs" attribution
+- `copyright.html` — Renders the version string (from `copyright` in `mkdocs.yml`), the release date (from `extra.release_date`), and the "Made with Material for MkDocs" attribution
 - `source-file.html` — Empty override to suppress the default in-content date display (moved to footer)
 
-The `copyright` field in `mkdocs.yml` is automatically updated by the release workflow during version bumps. The deploy-pages job rebuilds the docs from source so the deployed site always reflects the current version.
+Both `copyright` and `extra.release_date` in `mkdocs.yml` are automatically updated by the release workflow during version bumps. The deploy-pages job rebuilds the docs from source so the deployed site always reflects the current version and release date.
 
 ### Build Artifacts
 

--- a/public-docs/mkdocs.yml
+++ b/public-docs/mkdocs.yml
@@ -105,6 +105,9 @@ markdown_extensions:
 
 copyright: "RGFX v1.4.3"
 
+extra:
+  release_date: "{RELEASE_DATE}"
+
 extra_css:
   - assets/css/custom.css
 

--- a/public-docs/overrides/partials/copyright.html
+++ b/public-docs/overrides/partials/copyright.html
@@ -4,9 +4,9 @@
       {{ config.copyright }}
     </div>
   {% endif %}
-  {% if page and page.meta and page.meta.git_revision_date_localized %}
+  {% if config.extra.release_date %}
     <div class="md-copyright__updated">
-      Last updated: {{ page.meta.git_revision_date_localized }}
+      Released: {{ config.extra.release_date }}
     </div>
   {% endif %}
   {% if not config.extra.generator == false %}


### PR DESCRIPTION
## Summary
- Footer date now shows the actual release date instead of when docs source files were last committed in git
- Release workflow stamps both version and date into `mkdocs.yml` via sed during the bump step
- New `extra.release_date` field in `mkdocs.yml` replaces the `git-revision-date-localized` plugin output in the footer

## Test plan
- [ ] Verify docs footer shows `Released: {RELEASE_DATE}` locally (placeholder until next release)
- [ ] Verify release workflow YAML is valid
- [ ] Next release should show correct date in footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)