### PR TITLE
Fix NSIS build failure from duplicate MUI include

### DIFF
--- a/rgfx-hub/build/installer.nsh
+++ b/rgfx-hub/build/installer.nsh
@@ -1,8 +1,6 @@
 ; RGFX Hub - Custom NSIS installer script
 ; Adds Windows Firewall rules so the hub can communicate with ESP32 drivers
 
-!include "MUI.nsh"
-
 !macro customInstall
   ; Remove any existing rule first to prevent duplicates on reinstall/upgrade
   nsExec::ExecToLog 'netsh advfirewall firewall delete rule name="RGFX Hub"'


### PR DESCRIPTION
## Summary

- Remove `!include "MUI.nsh"` from `installer.nsh` — electron-builder's NSIS template already includes MUI2, causing a macro parameter conflict (`MUI_SET requires 1 parameter, passed 2`) that broke the Windows installer build.

## Test plan

- [ ] CI: Windows installer build passes
- [ ] Manual: verify firewall rules still created on install/uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)