### PR TITLE
Add MAME cfg/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 
+# MAME
+cfg/
+
 # Python
 __pycache__/
 


### PR DESCRIPTION
## Summary
- Add `cfg/` to `.gitignore` to prevent MAME auto-generated config files from being tracked when MAME is launched from the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)