### PR TITLE
Add version to Release workflow run name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: "Release ${{ inputs.version }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Add `run-name: "Release ${{ inputs.version }}"` to the release workflow so GitHub Actions runs display the version being released (e.g., "Release v1.5.0") instead of the generic workflow name

## Test plan

- [ ] Trigger a release workflow run and verify the run name shows the version

🤖 Generated with [Claude Code](https://claude.com/claude-code)